### PR TITLE
Issue5 add hyperlinks dashboard widgets

### DIFF
--- a/src/web/components/AddToDashboardMenuRev.jsx
+++ b/src/web/components/AddToDashboardMenuRev.jsx
@@ -1,0 +1,212 @@
+import React, { PropTypes } from 'react';
+import { ButtonGroup, DropdownButton, MenuItem } from 'react-bootstrap';
+import Immutable from 'immutable';
+
+import StoreProvider from 'injection/StoreProvider';
+const SearchStore = StoreProvider.getStore('Search');
+const DashboardsStore = StoreProvider.getStore('Dashboards');
+const WidgetsStore = StoreProvider.getStore('Widgets');
+
+import PermissionsMixin from 'util/PermissionsMixin';
+import { WidgetCreationModal } from 'components/widgets';
+import { EditDashboardModal } from 'components/dashboard';
+
+const AddToDashboardMenuRev = React.createClass({
+  propTypes: {
+    widgetType: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+    bsStyle: PropTypes.string,
+    configuration: PropTypes.object,
+    fields: PropTypes.array,
+    hidden: PropTypes.bool,
+    pullRight: PropTypes.bool,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.element),
+      PropTypes.element,
+    ]),
+  },
+
+  mixins: [PermissionsMixin],
+
+  getInitialState() {
+    return {
+      dashboards: undefined,
+      selectedDashboard: '',
+    };
+  },
+
+  getDefaultProps() {
+    return {
+      bsStyle: 'info',
+      configuration: {},
+      hidden: false,
+      pullRight: false,
+    };
+  },
+
+  componentDidMount() {
+    this._initializeDashboards();
+  },
+  _initializeDashboards() {
+    DashboardsStore.addOnWritableDashboardsChangedCallback((dashboards) => {
+      if (this.isMounted()) {
+        this._updateDashboards(dashboards);
+      }
+    });
+
+    const dashboards = DashboardsStore.writableDashboards;
+    // Trigger a dashboard update if the store haven't got any dashboards
+    if (dashboards.size === 0) {
+      DashboardsStore.updateWritableDashboards();
+      return;
+    }
+
+    this._updateDashboards(dashboards);
+  },
+  _updateDashboards(newDashboards) {
+    this.setState({ dashboards: newDashboards });
+  },
+  _selectDashboard(dashboardId) {
+    let config = this.props.configuration;
+    config.dashboardID = dashboardId;
+
+    this.setState({ selectedDashboard: dashboardId });
+    this.refs.widgetModal.open();
+  },
+  _saveWidget(title, configuration) {
+
+    configuration['dashboardID'] = this.state.selectedDashboard;
+    let widgetConfig = Immutable.Map(this.props.configuration);
+    let searchParams = Immutable.Map(SearchStore.getOriginalSearchParams());
+    if (searchParams.has('range_type')) {
+      switch (searchParams.get('range_type')) {
+        case 'relative':
+          const relativeTimeRange = Immutable.Map({
+            // Changes the "relative" key used to store relative time-range to "range"
+            range: searchParams.get('relative'),
+            type: 'relative',
+          });
+          searchParams = searchParams
+            .set('timerange', relativeTimeRange)
+            .delete('relative')
+            .delete('range_type');
+          break;
+        case 'absolute':
+          const from = searchParams.get('from');
+          const to = searchParams.get('to');
+          const absoluteTimeRange = Immutable.Map({
+            type: 'absolute',
+            from: from,
+            to: to,
+          });
+          searchParams = searchParams
+            .set('timerange', absoluteTimeRange)
+            .delete('from')
+            .delete('to')
+            .delete('range_type');
+          break;
+        case 'keyword':
+          const keywordTimeRange = Immutable.Map({
+            type: 'keyword',
+            keyword: searchParams.get('keyword'),
+          });
+          searchParams = searchParams
+            .set('timerange', keywordTimeRange)
+            .delete('keyword')
+            .delete('range_type');
+      }
+    }
+    // Stores stream ID with the right key name for the add widget request
+    if (searchParams.has('streamId')) {
+      searchParams = searchParams.set('stream_id', searchParams.get('streamId')).delete('streamId');
+    }
+    widgetConfig = searchParams.merge(widgetConfig).merge(configuration);
+    const promise = WidgetsStore.addWidget(this.state.selectedDashboard, this.props.widgetType, title, widgetConfig.toJS());
+    promise.done(() => this.refs.widgetModal.saved());
+  },
+  _createNewDashboard() {
+    this.refs.createDashboardModal.open();
+  },
+  _renderLoadingDashboardsMenu() {
+    return (
+      <DropdownButton bsStyle={this.props.bsStyle}
+                      bsSize="small"
+                      title={this.props.title}
+                      pullRight={this.props.pullRight}
+                      id="dashboard-selector-dropdown">
+        <MenuItem disabled>Loading dashboards...</MenuItem>
+      </DropdownButton>
+    );
+  },
+  _renderDashboardMenu() {
+    let dashboards = Immutable.List();
+
+    this.state.dashboards
+      .sortBy(dashboard => dashboard.title)
+      .forEach((dashboard, id) => {
+        dashboards = dashboards.push(
+          <MenuItem eventKey={id} key={dashboard.id}>
+            {dashboard.title}
+          </MenuItem>,
+        );
+      });
+
+    return (
+      <DropdownButton bsStyle={this.props.bsStyle}
+                      bsSize="small"
+                      title={this.props.title}
+                      pullRight={this.props.pullRight}
+                      onSelect={this._selectDashboard}
+                      id="dashboard-selector-dropdown">
+        {dashboards}
+      </DropdownButton>
+    );
+  },
+  _renderNoDashboardsMenu() {
+    const canCreateDashboard = this.isPermitted(this.props.permissions, ['dashboards:create']);
+    let option;
+    if (canCreateDashboard) {
+      option = <MenuItem key="createDashboard">No dashboards, create one?</MenuItem>;
+    } else {
+      option = <MenuItem key="noDashboards">No dashboards available</MenuItem>;
+    }
+
+    return (
+      <div style={{ display: 'inline' }}>
+        <DropdownButton bsStyle={this.props.bsStyle}
+                        bsSize="small"
+                        title={this.props.title}
+                        pullRight={this.props.pullRight}
+                        onSelect={canCreateDashboard ? this._createNewDashboard : () => {}}
+                        id="no-dashboards-available-dropdown">
+          {option}
+        </DropdownButton>
+        <EditDashboardModal ref="createDashboardModal" onSaved={this._selectDashboard} />
+      </div>
+    );
+  },
+  render() {
+    let dropdownMenu;
+    if (this.state.dashboards === undefined) {
+      dropdownMenu = this._renderLoadingDashboardsMenu();
+    } else {
+      dropdownMenu = (!this.props.hidden && (this.state.dashboards.size > 0 ? this._renderDashboardMenu() : this._renderNoDashboardsMenu()));
+    }
+
+    return (
+      <div style={{ display: 'inline-block' }}>
+        <ButtonGroup>
+          {this.props.children}
+          {dropdownMenu}
+        </ButtonGroup>
+        <WidgetCreationModal ref="widgetModal"
+                             widgetType={this.props.widgetType}
+                             onConfigurationSaved={this._saveWidget}
+                             fields={this.props.fields} />
+      </div>
+    );
+  },
+});
+
+export default AddToDashboardMenuRev;

--- a/src/web/components/FieldQuickValuesPlus.jsx
+++ b/src/web/components/FieldQuickValuesPlus.jsx
@@ -4,7 +4,7 @@ import {Button, DropdownButton, MenuItem} from 'react-bootstrap';
 import Reflux from 'reflux';
 
 import QuickValuesPlusVisualization from 'components/QuickValuesPlusVisualization';
-import AddToDashboardMenu from 'components/dashboard/AddToDashboardMenu';
+import AddToDashboardMenuRev from 'components/AddToDashboardMenuRev';
 import Spinner from 'components/common/Spinner';
 import StringUtils from 'util/StringUtils';
 import UIUtils from 'util/UIUtils';
@@ -18,6 +18,7 @@ const RefreshStore = StoreProvider.getStore('Refresh');
 const FieldQuickValuesPlus = React.createClass({
     propTypes: {
         permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+        dashboard_id: PropTypes.string,
     },
     mixins: [
         Reflux.connect(QuickValuesPlusStore),
@@ -120,9 +121,12 @@ const FieldQuickValuesPlus = React.createClass({
 
         return <ul className={`dropdown-menu ${configKey}-selector`}>{submenuItems}</ul>;
     },
+    echoStatus: '',
+
     render() {
         let content;
         let inner;
+        let myvalue;
 
         const submenus = [
             <li key="sort_order-submenu" className="dropdown-submenu left-submenu">
@@ -157,7 +161,7 @@ const FieldQuickValuesPlus = React.createClass({
             content = (
                 <div className="content-col">
                     <div className="pull-right">
-                        <AddToDashboardMenu title="Add to dashboard"
+                        <AddToDashboardMenuRev title="Add to dashboard"
                                             ref="thedash"
                                             widgetType={this.WIDGET_TYPE}
                                             configuration={{field: this.state.field, table_size: this.state.quickValuesOptions['table_size'], sort_order: this.state.quickValuesOptions['sort_order'], top_values: this.state.quickValuesOptions['top_values']}}
@@ -168,7 +172,7 @@ const FieldQuickValuesPlus = React.createClass({
                             <DropdownButton bsSize="small" className="quickvalues-settings" title="Customize" id="customize-quick-values-plus-dropdown" onToggle={() => this.toggleDropdown()} open={this.state.dropdownIsOpen} >
                                 {submenus}
                             </DropdownButton>
-                        </AddToDashboardMenu>
+                        </AddToDashboardMenuRev>
                     </div>
                     <h1>Quick Values for {this.state.field} {this.state.loadPending && <i
                         className="fa fa-spin fa-spinner"></i>}</h1>

--- a/src/web/components/QuickValuesPlusVisualization.jsx
+++ b/src/web/components/QuickValuesPlusVisualization.jsx
@@ -136,11 +136,30 @@ const QuickValuesPlusVisualization = React.createClass({
         replaySearchButton.innerHTML = "<i class='fa fa-external-link'></i>";
         return replaySearchButton.outerHTML;
     },
+    escape(searchTerm) {
+        var escapedTerm = String(searchTerm);
+
+        // Replace newlines.
+        escapedTerm = escapedTerm.replace(/\r\n/g, " ");
+        escapedTerm = escapedTerm.replace(/\n/g, " ");
+        escapedTerm = escapedTerm.replace(/<br>/g, " ");
+
+        // Escape all lucene special characters from the source: && || : \ / + - ! ( ) { } [ ] ^ " ~ * ?
+        escapedTerm = String(escapedTerm).replace(/(&&|\|\||[\:\\\/\+\-\!\(\)\{\}\[\]\^\"\~\*\?])/g, "\\$&");
+
+        if (/\s/g.test(escapedTerm)) {
+            escapedTerm = '"' + escapedTerm + '"';
+        }
+
+        return escapedTerm;
+    },
     _excludeQueryClick(term) {
-        let newquery = (this.props.config.query == "") ? "!" + this.props.config.field + ":" + term : this.props.config.query + " AND !" + this.props.config.field + ":" + term;
+        let escTerm = this.escape(term);
+        let newquery = (this.props.config.query == "") ? "!" + this.props.config.field + ":" + escTerm : this.props.config.query + " AND !" + this.props.config.field + ":" + escTerm;
+
         const config = this.props.config;
         config.query = newquery;
-        let widget = {}
+        let widget = {};
         // First, let's load the widget
         const loadWidgetPromise = WidgetsStore.loadWidget(this.props.config.dashboardID, this.props.id);
         loadWidgetPromise.then(
@@ -209,7 +228,9 @@ const QuickValuesPlusVisualization = React.createClass({
                 }
 
                 if (this.props.config.field) {
-                    let appendQuery = (this.props.config.query == "") ? this.props.config.field + ":" + `${d.term}` : this.props.config.query + " AND " + this.props.config.field + ":" + `${d.term}`;
+                    //Properly format strings containing spaces, backslashes and colons.
+                    let escTerm = this.escape(`${d.term}`);
+                    let appendQuery = (this.props.config.query == "") ? this.props.config.field + ":" + escTerm : this.props.config.query + " AND " + this.props.config.field + ":" + escTerm;
                     let replayURL = Routes.stream_search(this.props.config.stream_id, appendQuery, this._getTimeRange(), this.props.config.interval);
                     return `${colourBadge} <a href="${replayURL}">${d.term}</a>`;
 
@@ -239,9 +260,10 @@ const QuickValuesPlusVisualization = React.createClass({
                 columns.push((d) => this._getExcludeFromQueryButton(d.term));
             }
 
-
             columns.push((d) => {
-                let appendQuery = (this.props.config.query == "") ? this.props.config.field + ":" + `${d.term}` : this.props.config.query + " AND " + this.props.config.field + ":" + `${d.term}`;
+                //Properly format strings containing spaces, backslashes and colons.
+                let escTerm = this.escape(`${d.term}`);
+                let appendQuery = (this.props.config.query == "") ? this.props.config.field + ":" + escTerm : this.props.config.query + " AND " + this.props.config.field + ":" + escTerm;
                 let replayURL = Routes.stream_search(this.props.config.stream_id, appendQuery, this._getTimeRange(), this.props.config.interval);
                 return this._getTermReplyInNewWindowButton(replayURL);
             });
@@ -507,8 +529,8 @@ const QuickValuesPlusVisualization = React.createClass({
                         <thead>
                         <tr>
                           <th style={{ width: '50%' }}>Value</th>
-                          <th>%</th>
-                          <th>Count</th>
+                          <th style={{ alignItems: 'center' }}>%</th>
+                          <th style={{ alignItems: 'center' }}>#</th>
                             {this.props.displayAddToSearchButton &&
                             <th style={{ width: 30 }}>&nbsp;</th>
                             }
@@ -516,10 +538,10 @@ const QuickValuesPlusVisualization = React.createClass({
                             <th style={{ width: 30 }}>&nbsp;</th>
                             }
                             {this.props.config.dashboardID &&
-                            <th style={{ width: 30 }}>&nbsp;</th>
+                            <th style={{ width: 28 }}>&nbsp;</th>
                             }
                             {this.props.config.field &&
-                            <th style={{ width: 30 }}>&nbsp;</th>
+                            <th style={{ width: 28 }}>&nbsp;</th>
                             }
                         </tr>
                         </thead>


### PR DESCRIPTION
This commit adds hyperlink support to the QuickValuesPlus dashboard widget. It provides support clicking on a term and being directed to the search page for that term as well as providing an icon on the right-hand side of the row to open the Term search in a new window. The term search will also ensure that the rest of the widget's query is included to help filter down the results.

Additionally, this commit provides another button for excluding the term from the Search Query. This makes it so that the widget can be updated from the dashboard without having to edit the dashboard. When the button is pressed, the query will modify the widget configuration and upon the next cache refresh, the term will be excluded. **Note**, this will only work if you have edit permissions on the dashboard. If the user does not have edit permissions, they will not see the exclude from query button.