### PR TITLE
Initial global defaults configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             <version>${graylog.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>1.4.1</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/graylog/plugins/quickvaluesplus/QuickValuesPlusPluginConfiguration.java
+++ b/src/main/java/org/graylog/plugins/quickvaluesplus/QuickValuesPlusPluginConfiguration.java
@@ -1,0 +1,49 @@
+package org.graylog.plugins.quickvaluesplus;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
+@AutoValue
+public abstract class QuickValuesPlusPluginConfiguration {
+
+    @JsonProperty("table_size")
+    public abstract Number tableSize();
+
+    @JsonProperty("top_values")
+    public abstract Number topValues();
+
+    @JsonProperty("sort_order")
+    public abstract String sortOrder();
+
+    @JsonCreator
+    public static QuickValuesPlusPluginConfiguration create(@JsonProperty("table_size") Number tableSize,
+                                                        @JsonProperty("top_values") Number topValues,
+                                                        @JsonProperty("sort_order") String sortOrder) {
+        return builder()
+                .tableSize(tableSize)
+                .topValues(topValues)
+                .sortOrder(sortOrder)
+                .build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_QuickValuesPlusPluginConfiguration.Builder();
+    }
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        public abstract Builder tableSize(Number tableSize);
+
+        public abstract Builder topValues(Number topValues);
+
+        public abstract Builder sortOrder(String sortOrder);
+
+        public abstract QuickValuesPlusPluginConfiguration build();
+    }
+
+}

--- a/src/main/java/org/graylog/plugins/quickvaluesplus/QuickValuesPlusWidgetModule.java
+++ b/src/main/java/org/graylog/plugins/quickvaluesplus/QuickValuesPlusWidgetModule.java
@@ -1,12 +1,22 @@
 package org.graylog.plugins.quickvaluesplus;
 
 import org.graylog2.plugin.PluginModule;
+import org.graylog2.plugin.PluginConfigBean;
 import org.graylog.plugins.quickvaluesplus.widget.strategy.QuickValuesPlusWidgetStrategy;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Extend the PluginModule abstract class here to add you plugin to the system.
  */
 public class QuickValuesPlusWidgetModule extends PluginModule {
+
+    @Override
+    public Set<? extends PluginConfigBean> getConfigBeans() {
+        return Collections.emptySet();
+    }
+
     @Override
     protected void configure() {
         addWidgetStrategy(QuickValuesPlusWidgetStrategy.class, QuickValuesPlusWidgetStrategy.Factory.class);

--- a/src/web/components/QuickValuesPlusDefaultConfig.jsx
+++ b/src/web/components/QuickValuesPlusDefaultConfig.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { Input } from 'components/bootstrap';
+import { Button } from 'react-bootstrap';
+import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { IfPermitted, Select } from 'components/common';
+import ObjectUtils from 'util/ObjectUtils';
+
+const QuickValuesPlusDefaultConfig = React.createClass({
+    propTypes: {
+        config: React.PropTypes.object,
+        updateConfig: React.PropTypes.func.isRequired,
+    },
+
+    getDefaultProps() {
+        return {
+            config: {
+                sort_order: "descending",
+                table_size: 50,
+                top_values: 5,
+            },
+        };
+    },
+
+    getInitialState() {
+        return {
+            config: ObjectUtils.clone(this.props.config),
+        };
+    },
+
+    componentWillReceiveProps(newProps) {
+        this.setState({config: ObjectUtils.clone(newProps.config)});
+    },
+
+    _updateConfigField(field, value) {
+        const update = ObjectUtils.clone(this.state.config);
+        update[field] = value;
+        this.setState({config: update});
+    },
+
+    _onCheckboxClick(field, ref) {
+        return () => {
+            this._updateConfigField(field, this.refs[ref].getChecked());
+        };
+    },
+
+    _onSelect(field) {
+        return (selection) => {
+            this._updateConfigField(field, selection);
+        };
+    },
+
+    _onUpdate(field) {
+        return (e) => {
+            this._updateConfigField(field, e.target.value);
+        };
+    },
+
+    _openModal() {
+        this.refs.quickvaluesplusConfigModal.open();
+    },
+
+    _closeModal() {
+        this.refs.quickvaluesplusConfigModal.close();
+    },
+
+    _resetConfig() {
+        // Reset to initial state when the modal is closed without saving.
+        this.setState(this.getInitialState());
+    },
+
+    _saveConfig() {
+        this.props.updateConfig(this.state.config).then(() => {
+            this._closeModal();
+        });
+    },
+
+    render() {
+        return (
+            <div>
+                <h3>Quick Values Plus Configuration</h3>
+
+                <p>
+                    Defaults Configuration for the Quick Values Plus Field Analyzer and Widget
+                </p>
+
+                <dl className="deflist">
+                    <dt>Default Table Size</dt>
+                    <dd>{this.state.config.table_size}</dd>
+
+                    <dt>Default Top Values</dt>
+                    <dd>{this.state.config.top_values}</dd>
+
+                    <dt>Default Sort Order</dt>
+                    <dd>{this.state.config.sort_order === "descending" ? 'Descending' : 'Ascending'}</dd>
+                </dl>
+
+                <IfPermitted permissions="clusterconfigentry:edit">
+                    <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Configure</Button>
+                </IfPermitted>
+
+                <BootstrapModalForm ref="quickvaluesplusConfigModal"
+                                    title="Update Quick Values Plus plugin Configuration"
+                                    onSubmitForm={this._saveConfig}
+                                    onModalClose={this._resetConfig}
+                                    submitButtonText="Save">
+                    <fieldset>
+                        <Input key="dataTopValues"
+                               type="text"
+                               id="quickvaluesplus-top-values"
+                               name="top_values"
+                               label="Number of Top Values"
+                               value={this.state.config.top_values}
+                               onChange={this._onUpdate('top_values')}
+                               help="Modify the number of results that are considered Top Values in the table."/>
+
+                        <Input key="dataTableSize"
+                               type="text"
+                               id="quickvaluesplus-tables-size"
+                               name="table_size"
+                               label="Size of Table"
+                               value={this.state.config.table_size}
+                               onChange={this._onUpdate('table_size')}
+                               help="Modify the number of results in the table."/>
+
+                        <label for="quickvaluesplus-sort-order-descending" class="control-label"><span>Sort Order</span></label>
+                        <div className="radio">
+                            <label>
+                                <input key="dataSortOrderDesc"  id="quickvaluesplus-sort-order-descending" type="radio" name="sort_order" value="descending"
+                                       onChange={this._onUpdate('sort_order')}
+                                       checked={this.state.config.sort_order === "descending"} />
+                                Descending
+                            </label>
+                        </div>
+                        <div className="radio">
+                            <label>
+                                <input key="dataSortOrderAsc" id="quickvaluesplus-sort-order-ascending" type="radio" name="sort_order" value="ascending"
+                                       onChange={this._onUpdate('sort_order')}
+                                       checked={this.state.config.sort_order === "ascending"} />
+                                Ascending
+                            </label>
+                        </div>
+                    </fieldset>
+                </BootstrapModalForm>
+            </div>
+        );
+    },
+});
+
+export default QuickValuesPlusDefaultConfig;

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -7,6 +7,7 @@ import QuickValuesPlusVisualization from 'components/QuickValuesPlusVisualizatio
 import FieldQuickValuesPlus from 'components/FieldQuickValuesPlus';
 import QuickValuesPlusWidgetCreateConfiguration from 'components/QuickValuesPlusWidgetCreateConfiguration';
 import QuickValuesPlusWidgetEditConfiguration from 'components/QuickValuesPlusWidgetEditConfiguration'
+import QuickValuesPlusDefaultConfig from 'components/QuickValuesPlusDefaultConfig';
 
 PluginStore.register(new PluginManifest(packageJson, {
     widgets: [
@@ -26,6 +27,12 @@ PluginStore.register(new PluginManifest(packageJson, {
             displayName: 'Quick Values Plus',
             component: FieldQuickValuesPlus,
             displayPriority: 10,
+        },
+    ],
+    systemConfigurations: [
+        {
+            component: QuickValuesPlusDefaultConfig,
+            configType: 'org.graylog.plugins.quickvaluesplus.QuickValuesPlusPluginConfiguration',
         },
     ],
 }));


### PR DESCRIPTION
Adds necessary code to provide System Configuration support for the plugin's default values instead of having the values hard-coded into the field analyzer. Related to Issue #9 