### PR TITLE
Fixed null issue, added migration for blank configurations. Bumped ve…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ New Global System Configuration
 
 Supported Graylog Versions
 -----------
-* Version 3.0.0 was tested and is compatible with Graylog version 2.3.0 and above.
+* Version 3.0.1 was tested and is compatible with Graylog version 2.3.0 and above.
 * Version 2.1.0 was tested and is compatible with Graylog versions 2.2.1, 2.2.2, and 2.2.3.
 * Version 1.0.0 was tested and is compatible with Graylog version 2.1.3.
  
@@ -73,37 +73,40 @@ Way Ahead - Version 3.1.0
 -----------
  * Add additional Default Configuration options (show table, show pie chart, links, exclude query button)
  * Add ability to Turn Off links and/or exclude from Query buttons for each individual widget in the Widget Configuration.
-  
+ * Add debug configuration option to enable console messaging in order to help in troubleshooting issues with the plugin.
+   
 Development
 -----------
 You can improve your development experience for the web interface part of your plugin dramatically by making use of hot reloading. 
 
 To hot reload using Graylog 2.3.0, your plugin directory should be located two directories above your graylog2-web-server directory (../../) and the folder name of your plugin should be begin with graylog-plugin (More info[HERE](https://github.com/Graylog2/graylog2-server/blob/2.3/graylog2-web-interface/webpack.combined.config.js#L11))
 
-Steps for hot-loading setup with the plugin.
+#####Steps for hot-loading setup with the plugin.
 * Clone the Repositories
 ```
+git clone -b "2.3.1" https://github.com/Graylog2/graylog2-server.git
 git clone https://github.com/billmurrin/graylog-plugin-quickvaluesplus-widget.git
-git clone -b "2.3.0" https://github.com/Graylog2/graylog2-server.git
 ```
-* Install the Node.JS modules
+* Install the `graylog2-web-interface` node modules and build the Vendor Manifest
+```
+cd graylog2-server/graylog2-web-interface
+npm install
+webpack --config webpack.vendor.js
+```
+* Install the `graylog-plugin-quickvaluesplus-widget` node modules
 ```
 cd graylog-plugin-quickvaluesplus-widget
 npm install
-cd ../graylog2-server/graylog2-web-interface
-npm install
 ```
-* Build the Vendor file (If you skip this, plugin might fail with an 'call an undefined function')
+
+* From within `graylog2-web-interface`, start the web server
 ```
-webpack --config webpack.vendor.js
-```
-* Start the web server
-```
+cd graylog2-server/graylog2-web-interface
 npm start
 ```
 
-Steps to build the plugin.
-* Follow the steps above, but **DO NOT** run the `npm start` command. (no need to start the dev web-server) 
+#####Steps to build the plugin.
+* Follow the steps above for hot-loading, but **DO NOT** run the `npm start` command. (no need to start the dev web-server) 
 * Run `mvn package` 
-* Copy the generated JAR file located in the target directory to the Graylog plugin directory.
+* Copy the generated JAR file located in the `/target` folder to the Graylog plugin directory.
 * Restart Graylog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "QuickValuesPlusWidget",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "GrayLog2 QuickValuesPlus Widget Plugin",
   "repository": {
     "type": "git",

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.graylog.plugins</groupId>
     <artifactId>graylog-plugin-quickvaluesplus-widget</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/org/graylog/plugins/quickvaluesplus/QuickValuesPlusDefaultValuesMigration.java
+++ b/src/main/java/org/graylog/plugins/quickvaluesplus/QuickValuesPlusDefaultValuesMigration.java
@@ -1,0 +1,42 @@
+package org.graylog.plugins.quickvaluesplus;
+
+import org.graylog2.migrations.Migration;
+import org.graylog2.cluster.ClusterConfigServiceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+
+
+/**
+ * Migration creating the quick values plus entries if they do not exist.
+ */
+public class QuickValuesPlusDefaultValuesMigration extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(QuickValuesPlusDefaultValuesMigration.class);
+
+    private final ClusterConfigServiceImpl clusterConfigService;
+
+    @Inject
+    public QuickValuesPlusDefaultValuesMigration(final ClusterConfigServiceImpl clusterConfigService) {
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2017-09-03T01:57:00Z");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void upgrade() {
+        if (clusterConfigService.get(QuickValuesPlusPluginConfiguration.class) != null) {
+            LOG.debug("Migration already done.");
+            return;
+        }
+
+        LOG.info("Writing values for Quick Values Plugin Configuration");
+        clusterConfigService.write(QuickValuesPlusPluginConfiguration.create(25, 5, "descending"));
+    }
+
+}

--- a/src/main/java/org/graylog/plugins/quickvaluesplus/QuickValuesPlusWidgetModule.java
+++ b/src/main/java/org/graylog/plugins/quickvaluesplus/QuickValuesPlusWidgetModule.java
@@ -3,7 +3,10 @@ package org.graylog.plugins.quickvaluesplus;
 import org.graylog2.plugin.PluginModule;
 import org.graylog2.plugin.PluginConfigBean;
 import org.graylog.plugins.quickvaluesplus.widget.strategy.QuickValuesPlusWidgetStrategy;
-
+import com.github.joschi.jadconfig.Parameter;
+import com.google.inject.multibindings.Multibinder;
+import org.graylog2.migrations.Migration;
+import org.graylog.plugins.quickvaluesplus.QuickValuesPlusDefaultValuesMigration;
 import java.util.Collections;
 import java.util.Set;
 
@@ -11,6 +14,10 @@ import java.util.Set;
  * Extend the PluginModule abstract class here to add you plugin to the system.
  */
 public class QuickValuesPlusWidgetModule extends PluginModule {
+
+    protected Multibinder<Migration> migrationsBinder() {
+        return Multibinder.newSetBinder(binder(), Migration.class);
+    }
 
     @Override
     public Set<? extends PluginConfigBean> getConfigBeans() {
@@ -20,5 +27,7 @@ public class QuickValuesPlusWidgetModule extends PluginModule {
     @Override
     protected void configure() {
         addWidgetStrategy(QuickValuesPlusWidgetStrategy.class, QuickValuesPlusWidgetStrategy.Factory.class);
+
+        migrationsBinder().addBinding().to(QuickValuesPlusDefaultValuesMigration.class);
     }
 }


### PR DESCRIPTION
A migration for the Plugin did not occur to populate the initial configuration values. This was causing the configuration to be present, but the values would be null since the fields did not exist in the database. 

If a user did visit and save the system configuration of the plugin, then they never received the error and it worked normally.

I was able to test that the migration worked properly by removing the mongo record and then restarting the plugin.

This PR also fixes an issue where when using reloading or loading a saved search in the same window it was resetting the values to what was stored in the configuration instead of using the currently selected value set by the user via the Options Menu. The behavior now works properly and only resets the configuration upon being Dismissed.